### PR TITLE
Don't send XTRAFFIC on user aircraft

### DIFF
--- a/EFBConnect/DataStructures.cs
+++ b/EFBConnect/DataStructures.cs
@@ -53,6 +53,9 @@ namespace EFBConnect
 
         [DataItem("ATC FLIGHT NUMBER", 8)]
         public string FlightNumber;
+
+        [DataItem("IS USER SIM", "bool")]
+        public bool UserSim;
     }
 
     [DataStruct()]

--- a/EFBConnect/ForeFlightUdp.cs
+++ b/EFBConnect/ForeFlightUdp.cs
@@ -86,14 +86,18 @@ namespace EFBConnect
             {
                 if (udpSocket != null)
                 {
-                    var trafficDatagram = string.Format(
-                        "XTRAFFIC{0},{1},{2:0.#####},{3:0.#####},{4:0.#},{5:0.#},{6},{7:0.###},{8:0.#},{9}",
-                        simIdent, dwObjectID, t.Latitude, t.Longitude, t.Altitude, t.VerticalSpeed,
-                        t.OnGround ? 0 : 1, t.TrueHeading, t.GroundVelocity,
-                        (string.IsNullOrEmpty(t.Airline) || string.IsNullOrEmpty(t.FlightNumber)) ? t.TailNumber : t.Airline + " " + t.FlightNumber
-                        );
-                    udpSocket.SendTo(Encoding.ASCII.GetBytes(trafficDatagram), ipEndPoint);
-                    //log.Info(trafficDatagram);
+                    if (t.UserSim == false)
+                    {
+                        var trafficDatagram = string.Format(
+                            "XTRAFFIC{0},{1},{2:0.#####},{3:0.#####},{4:0.#},{5:0.#},{6},{7:0.###},{8:0.#},{9}",
+                            simIdent, dwObjectID, t.Latitude, t.Longitude, t.Altitude, t.VerticalSpeed,
+                            t.OnGround ? 0 : 1, t.TrueHeading, t.GroundVelocity,
+                            (string.IsNullOrEmpty(t.Airline) || string.IsNullOrEmpty(t.FlightNumber)) ? t.TailNumber : t.Airline + " " + t.FlightNumber
+                            );
+                        udpSocket.SendTo(Encoding.ASCII.GetBytes(trafficDatagram), ipEndPoint);
+                        //log.Info(trafficDatagram);
+                    }
+
                 }
             }
         }


### PR DESCRIPTION
The user's aircraft was being detected when requesting data for simobjects nearby, this would mean that another aircraft would be displayed on top of your position on the EFB software (and would also result in traffic alerts). This fixes that by checking if the simobject is the user loaded aircraft before sending the XTRAFFIC UDP data, if it is the user's aircraft then it won't send.