### PR TITLE
Update ForeFlightUdp.cs

### DIFF
--- a/EFBConnect/ForeFlightUdp.cs
+++ b/EFBConnect/ForeFlightUdp.cs
@@ -16,7 +16,7 @@ namespace EFBConnect
         private IPEndPoint ipEndPoint;
         private Log log;
         private string simIdent;
-        private const int foreFlightPort = 49002;
+        private const int foreFlightPort = 49000;
 
         private ForeFlightUdp()
         {


### PR DESCRIPTION
Good day, I have absolutely no knowledge of programming. How would you be able to change the port. I would like to use it on a different application called Helios Horizon that uses Xplane format for UDP  but send data from MSFS 2020 instead.

I have downloaded the .exe for EFBConnect, however there in no way to change the UDP port. 